### PR TITLE
common: sepolicy: fix DAC panel denials

### DIFF
--- a/sepolicy/private/dac_panel_app.te
+++ b/sepolicy/private/dac_panel_app.te
@@ -5,13 +5,20 @@ app_domain(dac_panel_app)
 binder_call(dac_panel_app, hal_dac_control_default)
 binder_call(dac_panel_app, gpuservice)
 
-allow dac_panel_app system_app_data_file:dir { rw_dir_perms create };
-allow dac_panel_app system_app_data_file:file { rw_file_perms create rename setattr unlink };
+allow dac_panel_app system_app_data_file:dir create_dir_perms;
+allow dac_panel_app system_app_data_file:file create_file_perms;
 
-allow dac_panel_app { activity_service activity_task_service
-                      audio_service audioserver_service
-                      autofill_service gpu_service
-                      media_session_service surfaceflinger_service }:service_manager find;
+allow dac_panel_app { 
+    activity_service 
+    activity_task_service
+    audio_service 
+    audioserver_service
+    autofill_service 
+    gpu_service
+    media_session_service 
+    permission_checker_service
+    surfaceflinger_service 
+}:service_manager find;
 
 allow dac_panel_app hal_dac_control_hwservice:hwservice_manager find;
 


### PR DESCRIPTION
App needs to access permission checker service:
avc:  denied  { find } for pid=7932 uid=1000 name=permission_checker scontext=u:r:dac_panel_app:s0 tcontext=u:object_r:permission_checker_service:s0 tclass=service_manager permissive=0

Change-Id: I386eedaab03c0e31c9220fc1182086c98d73882e